### PR TITLE
[DRAFT] ci: add initial container build and deploy actions

### DIFF
--- a/.github/workflows/callable-build-docker.yml
+++ b/.github/workflows/callable-build-docker.yml
@@ -1,0 +1,84 @@
+name: "Task: Build"
+on:
+  workflow_call:
+    inputs:
+      override_sha:
+        description: 'Optionally force checkout of a specific sha'
+        default: ''
+        type: string
+      push:
+        description: 'To push or not to push'
+        required: true
+        type: boolean
+    outputs:
+      container_image_digest:
+        description: "The sha256 digest of the built container image"
+        value: ${{ jobs.docker.outputs.digest }}
+
+permissions:
+  packages: write
+  contents: read
+  attestations: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ inputs.override_sha != '' }}
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.override_sha }}
+
+      - uses: actions/checkout@v4
+        if: ${{ inputs.override_sha == '' }}
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DOCKER_PUSH_IAM_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          context: workflow
+          images: "544847369688.dkr.ecr.us-east-2.amazonaws.com/data-reports"
+          tags: |-
+            ${{ inputs.override_sha == '' && 'type=ref,event=branch' || '' }}
+            ${{ inputs.override_sha == '' && 'type=ref,event=tag' || '' }}
+            ${{ inputs.override_sha == '' && 'type=ref,event=pr' || '' }}
+            ${{ inputs.override_sha == '' && '# skip raw sha' || format('type=raw,value=sha-{0}', inputs.override_sha) }}
+          labels: |-
+            ${{ inputs.override_sha != '' && 'org.opencontainers.image.version=unknown' }}
+            ${{ inputs.override_sha != '' && format('org.opencontainers.image.revision={0}', inputs.override_sha) }}
+          flavor: |
+            latest=false
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ inputs.push }}
+          platforms: "linux/amd64"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/callable-deploy-ecs.yml
+++ b/.github/workflows/callable-deploy-ecs.yml
@@ -1,0 +1,84 @@
+name: "Task: Deploy"
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: Target environment of deployment. (stg, prod)
+        required: true
+        type: string
+      container_digest:
+        description: 'The container sha256 digest to deploy'
+        required: true
+        type: string
+
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+concurrency:
+  group: ${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: data-reports
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.env }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.IAM_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ vars.ECS_TASK_DEF_FAMILY }} \
+            --query taskDefinition \
+            > task.json
+          
+          # Remove Ignored Properties
+
+          echo "$( jq 'del(.compatibilities)'    task.json )" > task.json
+          echo "$( jq 'del(.taskDefinitionArn)'  task.json )" > task.json
+          echo "$( jq 'del(.requiresAttributes)' task.json )" > task.json
+          echo "$( jq 'del(.revision)'           task.json )" > task.json
+          echo "$( jq 'del(.status)'             task.json )" > task.json
+          echo "$( jq 'del(.registeredAt)'       task.json )" > task.json
+          echo "$( jq 'del(.registeredBy)'       task.json )" > task.json
+
+          # Update Image
+          echo "$( jq --arg image "544847369688.dkr.ecr.us-east-2.amazonaws.com/data-reports@${{ inputs.container_digest }}" '.containerDefinitions |= map((select(.name == "flask") | .image) |= $image)' task.json )" > task.json
+          cat task.json
+
+      - name: Deploy Amazon ECS task definition
+        id: ecs-deploy
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: task.json
+          service: ${{ vars.ECS_SERVICE }}
+          cluster: ${{ vars.ECS_CLUSTER }}
+          wait-for-service-stability: true
+          propagate-tags: SERVICE
+
+      - name: Verify deploy
+        id: check-deployment
+        run: |
+          TASK_DEF_EXPECTED=${{ steps.ecs-deploy.outputs.task-definition-arn }}
+          TASK_DEF_CURRENT=$(
+            aws ecs describe-services \
+              --cluster ${{ vars.ECS_CLUSTER }} \
+              --services ${{ vars.ECS_SERVICE }} \
+              --query services[0].deployments[0].taskDefinition \
+              | jq -r "."
+          )
+          echo "Task Arn - Current: $TASK_DEF_CURRENT"
+          echo "Task Arn - Expected: $TASK_DEF_EXPECTED"
+          if [ "$TASK_DEF_CURRENT" != "$TASK_DEF_EXPECTED" ]; then
+            echo "Current task arn does not match the expected task arn."
+            echo "The deployment may have been rolled back or been deposed by a more recent deployment attempt"
+            exit 1
+          fi

--- a/.github/workflows/manual-deploy-sha.yml
+++ b/.github/workflows/manual-deploy-sha.yml
@@ -1,0 +1,90 @@
+name: 'Manual Deploy: Git Sha'
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        type: string
+        required: true
+        description: Git sha (long format) to build and deploy
+      env:
+        type: environment
+        default: stg
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.sha }}
+  cancel-in-progress: false
+
+jobs:
+  # This job builds a new container and deploys it to the target environment. It
+  # is unsafe to deploy such arbitrary builds directly to production without
+  # first trialing them in lower environments.
+
+  validate:
+    name: "Validate Inputs"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify not production
+        if: ${{ inputs.env == 'prod' }}
+        run: |
+          cat << EOF
+          #---------------------------------------------------------------------------------
+          # ERROR: Cannot deploy arbitrary sha to production
+          #---------------------------------------------------------------------------------
+          # 
+          # DETAILS:
+          # 
+          # This job builds a new container and deploys it to the target environment. It
+          # is unsafe to deploy such arbitrary builds directly to production without
+          # first trialing them in lower environments.
+          # 
+          # WORKAROUND:
+          # 
+          # If you truely must release a specific sha,
+          # 
+          #   1) Use this workflow to build and deploy the sha to staging
+          #   2) Deploy the assigned tag from that deployment using the
+          #      "Manual Deploy: Docker Tag" workflow
+          #      Note: You must cite a DOCKER tag
+          #      Which should look like "sha-9e14d6f3da3c3c3f7ea73b74dec8c931365745e4"
+          # 
+          #---------------------------------------------------------------------------------
+          EOF
+          exit 1
+      - name: Verify sha is hex
+        run: |
+          if [[ ! "${{ inputs.sha }}" =~ ^[0-9A-Fa-f]+$ ]]; then
+            echo "sha must be hexidecimal"; exit 1
+          fi
+
+          length=$(expr length "${{ inputs.sha }}")
+          if [ "$length" != "40" ]; then
+            echo "sha must be all 40 characters"; exit 1
+          fi
+          
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Verify commit exists
+        run: |
+          git cat-file commit ${{ inputs.sha }}
+
+  build-docker:
+    name: "Build"
+    uses: ./.github/workflows/callable-build-docker.yml
+    secrets: inherit
+    with:
+      override_sha: ${{ inputs.sha }}
+      push: true
+    needs:
+      - validate
+
+  deploy-ecs:
+    name: "Deploy container to ECS"
+    uses: ./.github/workflows/callable-deploy-ecs.yml
+    secrets: inherit
+    with:
+      env: ${{ inputs.env }}
+      container_digest: ${{ needs.build-docker.outputs.container_image_digest }}
+    needs: 
+      - build-docker

--- a/.github/workflows/manual-deploy-tag.yml
+++ b/.github/workflows/manual-deploy-tag.yml
@@ -1,0 +1,63 @@
+name: 'Manual Deploy: Docker Tag'
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: Tag of the DOCKER image to deploy
+      env:
+        type: environment
+        default: stg
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+
+  locate:
+    name: Find Target Image
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.inspect.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DOCKER_PUSH_IAM_ROLE_ARN }}
+          aws-region: us-east-2
+  
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Pull target tag & inspect
+        id: inspect
+        run: |
+          set -e
+
+          TARGET_IMAGE="544847369688.dkr.ecr.us-east-2.amazonaws.com/data-reports:${{ inputs.tag }}"
+          docker pull $TARGET_IMAGE
+          checksum=$(
+            docker inspect $TARGET_IMAGE \
+              | jq '.[].RepoDigests.[]' \
+              | tr -d '"' \
+              | sed 's/^.*@//'
+          )
+
+          echo "digest=${checksum}" >> "$GITHUB_OUTPUT"
+  deploy:
+    name: "Deploy"
+    uses: ./.github/workflows/callable-deploy-ecs.yml
+    secrets: inherit
+    with:
+      env: ${{ inputs.env }}
+      container_digest: ${{ needs.locate.outputs.digest }}
+    needs:
+      - locate

--- a/.github/workflows/on-merge-to-master.yml
+++ b/.github/workflows/on-merge-to-master.yml
@@ -1,0 +1,29 @@
+name: On Branch Update (master)
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+
+  build-docker:
+    name: "Build"
+    uses: ./.github/workflows/callable-build-docker.yml
+    secrets: inherit
+    with:
+      push: true
+
+  deploy-env-stg:
+    name: "Deploy Staging"
+    uses: ./.github/workflows/callable-deploy-ecs.yml
+    secrets: inherit
+    with:
+      env: stg
+      container_digest: ${{ needs.build-docker.outputs.container_image_digest }}
+    needs: 
+      - build-docker

--- a/.github/workflows/on-pr-update.yml
+++ b/.github/workflows/on-pr-update.yml
@@ -1,0 +1,21 @@
+name: On Pull Request Update
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docker:
+    name: "Build"
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    uses: ./.github/workflows/callable-build-docker.yml
+    secrets: inherit
+    with:
+      push: false

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -1,0 +1,28 @@
+name: On Tag
+on:
+  push:
+    tags:
+      - "*"
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build-docker:
+    name: "Build"
+    uses: ./.github/workflows/callable-build-docker.yml
+    secrets: inherit
+    with:
+      push: true
+
+  deploy-stg:
+    name: "Deploy Staging"
+    uses: ./.github/workflows/callable-deploy-ecs.yml
+    secrets: inherit
+    with:
+      env: stg
+      container_digest: ${{ needs.build-docker.outputs.container_image_digest }}
+    needs: 
+      - build-docker


### PR DESCRIPTION
Still a draft here, not ready to merge.

~~~

Create github actions for building and deploying LAMP-cortex-cnl

## Manual Actions:
- **Deploy SHA** - Allows an authorized user to build and deploy an arbitrary git sha (long format) to staging or other future testing environments (note, cannot be used to deploy to production).
- **Deploy Tag** - Allows an authorized user to deploy a docker container to any configured environment (currently only `stg` and `prod`. Note that the input for this job is the _DOCKER_ tag, not the git tag. Likely, the docker tags will be in the form of `master`, `sha-somelongformatgitsha`, or `gittag` (eg. `2024.5.9` as is the preferred format in this repository)

## Automatic Actions:
- **On Branch Update (master)** - Runs when a pull request is merged into master or when someone pushes a commit directly to master. The action will build a docker image, push it to our private elastic container registry (in our aws account) with the docker tag `master`, and deploy that image to the staging environment (`stg`) using the image's checksum digest.
- **On Pull Request Update** - Builds the docker image _without_ publishing it to the registry. Some notes here:
  - This action checks the validity of a pull request, it does not publish anything to the registry
  - The only check at the moment is that the image builds successfully. It does not check that the image can be booted.
  - The sha that is built is the sha of the invisible merge commit, not the HEAD of the branch. This could be a source of dependencies if it "works on my machine"
  - Because this action listens to the `edited` webhook type (among others), it will be triggered each time the base branch is updated. If there are lots of open pull requests, this could mean an unhelpful amount of rebuilds when master is updated.
- **On Tag** - Runs when a new tag is pushed to the repository. It is the same as the "On Branch Update (master)" job except that the resulting docker tag will be the name of the git tag pushed (eg git tag of `2024.5.9` will create a docker tag of `2024.5.9`)
  
## Tasks or Callable Workflows:
  
These two workflows should not be called directly, but instead called by an "On <event>"-style workflow. No need to do anything here, just wanted to explain all the new files. The "Build" task builds the docker image. The "Deploy" task deploys the docker task to the Digital Psych AWS ECS environment(s).
