### PR TITLE
fix: Add health check endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,6 +163,13 @@ def discover_reports_for(user: DynamoUser):
 # ────────────────────────────────────────────────────────────────────────────
 # Routes
 # ────────────────────────────────────────────────────────────────────────────
+@app.route("/service/healthz")
+def healthz():
+    return jsonify({
+        "status": "healthy",
+        "service": "data-reports"
+    }), 200
+
 @app.before_request
 def before_request():
     pass


### PR DESCRIPTION
We were failing health checks on ECS deployments with 404 errors for the /service/healthz endpoint. This change should resolve that issue.