### PR TITLE
fix: Update port to use environment variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -350,4 +350,4 @@ def generate_report():
 # Entrypoint
 # ────────────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, use_reloader=False)
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 5000)), use_reloader=False)


### PR DESCRIPTION
For local testing the app was pointed at port `5000` when it should point at the `PORT` environment variable. Opted to leave `5000` as a fallback option.